### PR TITLE
Add a function to get a card by the API key

### DIFF
--- a/src/main/java/io/magicthegathering/javasdk/api/CardAPI.java
+++ b/src/main/java/io/magicthegathering/javasdk/api/CardAPI.java
@@ -13,6 +13,14 @@ public class CardAPI extends MTGAPI {
 	private static final String RESOURCE_PATH = "cards";
 
 	/**
+	 * @return A {@link Card} based on the given cardid
+	 */
+	public static Card getCard(String cardId) {
+		String path = String.format("%s/%s/", RESOURCE_PATH, cardId);
+		return get(path, "card", Card.class);
+	}
+
+	/**
 	 * @return A {@link Card} based on the given multiverseid
 	 */
 	public static Card getCard(int multiverseId) {

--- a/src/test/java/io/magicthegathering/javasdk/api/CardAPITest.java
+++ b/src/test/java/io/magicthegathering/javasdk/api/CardAPITest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 public class CardAPITest extends MTGAPITest {
 
 	@Test
-	public void testGetCard() {
+	public void testGetCardByMultiverseId() {
 		Card testCard = new Card();
 		testCard.setMultiverseid(1);
 		testCard.setName("Ankh of Mishra");
@@ -22,6 +22,16 @@ public class CardAPITest extends MTGAPITest {
 		assertEquals(testCard, CardAPI.getCard(1));
 		assertFalse(testCard.equals(CardAPI.getCard(10)));
 	}
+
+  @Test
+  public void testGetCardById() {
+    Card testCard = new Card();
+    testCard.setMultiverseid(1);
+    testCard.setName("Ankh of Mishra");
+    testCard.setManaCost("{2}");
+    assertEquals(testCard, CardAPI.getCard("8a5d85644f546525433c4472b76c3b0ebb495b33"));
+    assertFalse(testCard.equals(CardAPI.getCard("926234c2fe8863f49220a878346c4c5ca79b6046")));
+  }
 
 	@Test
 	public void testBadCardId() throws Exception {

--- a/stubby/json/cards/8a5d85644f546525433c4472b76c3b0ebb495b33.json
+++ b/stubby/json/cards/8a5d85644f546525433c4472b76c3b0ebb495b33.json
@@ -1,0 +1,59 @@
+{
+    "card": {
+        "name": "Ankh of Mishra",
+        "manaCost": "{2}",
+        "cmc": 2,
+        "type": "Artifact",
+        "types": [
+            "Artifact"
+        ],
+        "rarity": "Rare",
+        "set": "LEA",
+        "setName": "Limited Edition Alpha",
+        "text": "Whenever a land enters the battlefield, Ankh of Mishra deals 2 damage to that land's controller.",
+        "artist": "Amy Weber",
+        "layout": "normal",
+        "multiverseid": 1,
+        "imageUrl": "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=1&type=card",
+        "rulings": [
+            {
+                "date": "2004-10-04",
+                "text": "This triggers on any land entering the battlefield. This includes playing a land or putting a land onto the battlefield using a spell or ability."
+            },
+            {
+                "date": "2004-10-04",
+                "text": "It determines the land’s controller at the time the ability resolves. If the land leaves the battlefield before the ability resolves, the land’s last controller before it left is used."
+            }
+        ],
+        "printings": [
+            "LEA",
+            "LEB",
+            "2ED",
+            "CED",
+            "CEI",
+            "3ED",
+            "4ED",
+            "5ED",
+            "6ED",
+            "MED",
+            "VMA"
+        ],
+        "originalText": "Ankh does 2 damage to anyone who puts a new land into play.",
+        "originalType": "Continuous Artifact",
+        "legalities": [
+            {
+                "format": "Commander",
+                "legality": "Legal"
+            },
+            {
+                "format": "Legacy",
+                "legality": "Legal"
+            },
+            {
+                "format": "Vintage",
+                "legality": "Legal"
+            }
+        ],
+        "id": "8a5d85644f546525433c4472b76c3b0ebb495b33"
+    }
+}

--- a/stubby/json/cards/926234c2fe8863f49220a878346c4c5ca79b6046.json
+++ b/stubby/json/cards/926234c2fe8863f49220a878346c4c5ca79b6046.json
@@ -1,0 +1,76 @@
+{
+	"card": {
+		"name": "Air Elemental",
+		"manaCost": "{3}{U}{U}",
+		"cmc": 5,
+		"colors": [
+			"Blue"
+		],
+		"colorIdentity": [
+			"U"
+		],
+		"type": "Creature — Elemental",
+		"types": [
+			"Creature"
+		],
+		"subtypes": [
+			"Elemental"
+		],
+		"rarity": "Uncommon",
+		"set": "LEA",
+		"setName": "Limited Edition Alpha",
+		"text": "Flying",
+		"flavor": "These spirits of the air are winsome and wild, and cannot be truly contained. Only marginally intelligent, they often substitute whimsy for strategy, delighting in mischief and mayhem.",
+		"artist": "Richard Thomas",
+		"power": "4",
+		"toughness": "4",
+		"layout": "normal",
+		"multiverseid": 94,
+		"imageUrl": "http://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=94&type=card",
+		"printings": [
+			"LEA",
+			"LEB",
+			"2ED",
+			"CED",
+			"CEI",
+			"3ED",
+			"4ED",
+			"5ED",
+			"PO2",
+			"6ED",
+			"S99",
+			"BRB",
+			"BTD",
+			"7ED",
+			"8ED",
+			"9ED",
+			"10E",
+			"DD2",
+			"M10",
+			"DPA",
+			"ME4",
+			"DD3_JVC"
+		],
+		"originalText": "Flying",
+		"originalType": "Summon — Elemental",
+		"legalities": [
+			{
+				"format": "Commander",
+				"legality": "Legal"
+			},
+			{
+				"format": "Legacy",
+				"legality": "Legal"
+			},
+			{
+				"format": "Modern",
+				"legality": "Legal"
+			},
+			{
+				"format": "Vintage",
+				"legality": "Legal"
+			}
+		],
+		"id": "926234c2fe8863f49220a878346c4c5ca79b6046"
+	}
+}

--- a/stubby/stubby-config.yaml
+++ b/stubby/stubby-config.yaml
@@ -36,6 +36,24 @@
     file: json/cards/10.json
     
 - request:
+    url: ^/cards/8a5d85644f546525433c4472b76c3b0ebb495b33/?$
+    method: GET
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+    file: json/cards/8a5d85644f546525433c4472b76c3b0ebb495b33.json
+
+- request:
+    url: ^/cards/926234c2fe8863f49220a878346c4c5ca79b6046/?$
+    method: GET
+  response:
+    status: 200
+    headers:
+      Content-Type: application/json
+    file: json/cards/926234c2fe8863f49220a878346c4c5ca79b6046.json
+
+- request:
     url: ^/cards/-1/?$
     method: GET
   response:


### PR DESCRIPTION
This can be useful when card ids are cached and need to be retrieved later.

Also, not all cards have multiverse ids so the current getCard function may not work in all cases