### PR TITLE
Fix queries with results spanning multiple pages

### DIFF
--- a/src/main/java/io/magicthegathering/javasdk/api/MTGAPI.java
+++ b/src/main/java/io/magicthegathering/javasdk/api/MTGAPI.java
@@ -5,6 +5,8 @@ import io.magicthegathering.javasdk.exception.HttpRequestFailedException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -105,8 +107,8 @@ public abstract class MTGAPI {
 				}
 				for (String[] params : paramList) {
 					if (params[1].contains("last")) {
-						numberOfPages = Integer.parseInt(
-								params[0].split("page=")[1].replace(">", ""));
+						Matcher matcher = Pattern.compile("page=[0-9]+").matcher(params[0]);
+						numberOfPages = (matcher.find()) ? Integer.parseInt(matcher.group().substring(5)) : 0;
 					}
 				}
 


### PR DESCRIPTION
CardAPI.getAllCards() can throw an error when using filters and the results span multiple "pages", due to incorrect parsing of the "page" parameter.

Parsing the URL correctly fixes this issue.

This issue is reproducible as follows:

```java
import io.magicthegathering.javasdk.api.CardAPI;
import io.magicthegathering.javasdk.resource.Card;

import java.util.ArrayList;
import java.util.List;

public class Test {

    public static void main(String[] args) {
        List<String> filters = new ArrayList<>();
        filters.add("types=artifact,creature");
        List<Card> cards = CardAPI.getAllCards(filters);
        System.out.println(String.format("Found %s cards", cards.size()));
    }

}
```

