### PR TITLE
Update MTGAPI.java

### DIFF
--- a/src/main/java/io/magicthegathering/javasdk/api/MTGAPI.java
+++ b/src/main/java/io/magicthegathering/javasdk/api/MTGAPI.java
@@ -105,8 +105,7 @@ public abstract class MTGAPI {
 				}
 				for (String[] params : paramList) {
 					if (params[1].contains("last")) {
-						numberOfPages = Integer.parseInt(
-								params[0].split("page=")[1].replace(">", ""));
+						numberOfPages = Integer.parseInt(params[0].substring(params[0].indexOf(PAGE_LINK_REQUEST) + PAGE_LINK_REQUEST.length(),params[0].indexOf(DELIM_LINK_FILTER, params[0].indexOf(PAGE_LINK_REQUEST)) >= 0 ?  params[0].indexOf(DELIM_LINK_FILTER, params[0].indexOf(PAGE_LINK_REQUEST)) :params[0].indexOf(DELIM_LINK_RESPONSE)));
 					}
 				}
 


### PR DESCRIPTION
Hi again!

When i first used the API, i got an error on this block when trying to perform a request without "page" parameter. 
My workaround was inserting the page parameter and manually iterate it to perform queryes over results.

Recently i found a closed pull request that was reporting the very same error.

Well, i built this line to perform what i think that the code wants to. Since it is trying to parse a numeric value, but the end of the String is not defined.

I took the liberty to also evaluate if the page parameter is the last of them. Case it's not, i'm searching for the next delimiter parameter, which i forgot to add on this update with other two variables.

Anticipated Sorryes about my mistake. 

Here are the Three used variables:

private static String PAGE_LINK_REQUEST = "page=";
    private static String DELIM_LINK_RESPONSE = ">";
    private static String DELIM_LINK_FILTER = "&";