### PR TITLE
change the jdk that travis uses since the old one is no longer supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 
-jdk: oraclejdk7
+jdk: openjdk7
 
 install: mvn install -DskipTests -Dgpg.skip


### PR DESCRIPTION
Fixing the travis-ci badge now that I took a second to look at it.