### PR TITLE
Updating okhttp to 4.12.0 and junit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,13 +139,13 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
-			<version>3.4.1</version>
+			<version>4.12.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		


### PR DESCRIPTION
Updating okhttp to 4.12.0 and junit to 4.13.1 to prevent CVE-2023-0833 and CVE-2020-15250